### PR TITLE
-crash if message ID equals a <space>, <tab> or newline fixed

### DIFF
--- a/project/src/channel_codec_wrapper.cpp
+++ b/project/src/channel_codec_wrapper.cpp
@@ -57,7 +57,7 @@ RPCRuntimeDecodedFunctionCall Channel_codec_wrapper::pop() {
 
 RPCRuntimeTransfer Channel_codec_wrapper::pop_completed_transfer() {
 	if (transfers.front().is_complete() == false) {
-		throw std::runtime_error("Tried to pop from an incomplete transfer");
+        throw std::runtime_error("RPC channelcodec: Tried to pop from an incomplete transfer");
 	}
 	auto transfer = std::move(transfers.front());
 	transfers.pop_front();

--- a/project/src/rpcruntime_decoded_param.cpp
+++ b/project/src/rpcruntime_decoded_param.cpp
@@ -67,7 +67,7 @@ int64_t RPCRuntimeDecodedParam::as_signed_integer() const {
 		case 8:
 			return parse_signed_int<int64_t>(data);
 	}
-	throw std::domain_error("Invalid amount of data to parse signed integer");
+    throw std::domain_error("RPC: Invalid amount of data to parse signed integer");
 }
 
 int64_t RPCRuntimeDecodedParam::as_integer() const

--- a/project/src/rpcruntime_encoded_function_call.cpp
+++ b/project/src/rpcruntime_encoded_function_call.cpp
@@ -49,7 +49,7 @@ RPCRuntimeEncodedParam &RPCRuntimeEncodedFunctionCall::get_parameter(const std::
 			return param;
 		}
 	}
-	throw std::runtime_error("invalid name: " + name);
+    throw std::runtime_error("RPC: invalid parameter name: " + name);
 }
 
 const RPCRuntimeFunction *RPCRuntimeEncodedFunctionCall::get_description() const

--- a/project/src/rpcruntime_encoded_param.cpp
+++ b/project/src/rpcruntime_encoded_param.cpp
@@ -56,9 +56,9 @@ void RPCRuntimeEncodedParam::set_value(int64_t value) {
 			set_integer_value(value);
 			break;
 		case RPCRuntimeParameterDescription::Type::array:
-			throw std::runtime_error("improper value type for this value: Given integer to array");
+            throw std::runtime_error("RPC: improper value type for this value: Given integer to array");
 		case RPCRuntimeParameterDescription::Type::structure:
-			throw std::runtime_error("improper value type for this value: Given integer to structure");
+            throw std::runtime_error("RPC: improper value type for this value: Given integer to structure");
 	}
 }
 
@@ -71,11 +71,11 @@ void RPCRuntimeEncodedParam::set_value(const std::string &value) {
 			set_array_value(value);
 			break;
 		case RPCRuntimeParameterDescription::Type::integer:
-			throw std::runtime_error("improper value type for this value: Given string to integer");
+            throw std::runtime_error("RPC: improper value type for this value: Given string to integer");
 		case RPCRuntimeParameterDescription::Type::character:
-			throw std::runtime_error("improper value type for this value: Given string to character");
+            throw std::runtime_error("RPC: improper value type for this value: Given string to character");
 		case RPCRuntimeParameterDescription::Type::structure:
-			throw std::runtime_error("improper value type for this value: Given string to structure");
+            throw std::runtime_error("RPC: improper value type for this value: Given string to structure");
 	}
 }
 
@@ -84,28 +84,28 @@ RPCRuntimeEncodedParam &RPCRuntimeEncodedParam::get_parameter(int index) {
 		case RPCRuntimeParameterDescription::Type::array: {
 			int elements = description->as_array().number_of_elements;
 			if (index < 0 || index > elements) {
-				throw std::runtime_error("invalid index for given array");
+                throw std::runtime_error("RPC: invalid index for given array");
 			}
 			return child_parameters[index];
 		} break;
 		case RPCRuntimeParameterDescription::Type::structure:
-			throw std::runtime_error("TODO");
+            throw std::runtime_error("RPC: TODO");
 			break;
 		default:
-			throw std::runtime_error("parameter does not have sub-parameters");
+            throw std::runtime_error("RPC: parameter does not have sub-parameters");
 	}
 }
 
 RPCRuntimeEncodedParam &RPCRuntimeEncodedParam::get_parameter(const std::string &name) {
 	if (description->get_type() != RPCRuntimeParameterDescription::Type::structure) {
-		throw std::runtime_error("parameter does not have named sub-parameters");
+        throw std::runtime_error("RPC: parameter does not have named sub-parameters");
 	}
 	for (auto &child : child_parameters) {
 		if (child.get_description()->get_parameter_name() == name) {
 			return child;
 		}
 	}
-	throw std::runtime_error("invalid parameter name \"" + name + "\" for struct of type \"" + description->get_parameter_type() + "\"");
+    throw std::runtime_error("RPC: invalid parameter name \"" + name + "\" for struct of type \"" + description->get_parameter_type() + "\"");
 }
 
 RPCRuntimeEncodedParam &RPCRuntimeEncodedParam::operator[](int index) {
@@ -129,7 +129,7 @@ RPCRuntimeEncodedParam &RPCRuntimeEncodedParam::operator=(const std::string &nam
 RPCRuntimeEncodedParam &RPCRuntimeEncodedParam::operator=(std::initializer_list<int64_t> data) {
 	int index = 0;
 	if (child_parameters.size() < data.size()) {
-		throw std::runtime_error("Gave " + std::to_string(data.size()) + " values to a parameter of type " + description->get_parameter_type());
+        throw std::runtime_error("RPC: Gave " + std::to_string(data.size()) + " values to a parameter of type " + description->get_parameter_type());
 	}
 	for (auto &n : data) {
 		child_parameters[index++] = n;
@@ -156,15 +156,15 @@ void RPCRuntimeEncodedParam::set_enum_value(const std::string &value) {
 			return;
 		}
 	}
-	throw std::runtime_error("invalid enum value " + value);
+    throw std::runtime_error("RPC: invalid enum value " + value);
 }
 
 void RPCRuntimeEncodedParam::set_array_value(const std::string &array) {
 	if (description->as_array().type.get_type() != RPCRuntimeParameterDescription::Type::character) {
-		throw std::runtime_error("Assigning a string to an array is only supported for arrays of characters, but got " + description->get_parameter_type());
+        throw std::runtime_error("RPC: Assigning a string to an array is only supported for arrays of characters, but got " + description->get_parameter_type());
 	}
 	if (array.size() > child_parameters.size()) {
-		throw std::runtime_error("Given string \"" + array + "\" of length " + std::to_string(array.size()) + " doesn't fit into " +
+        throw std::runtime_error("RPC: Given string \"" + array + "\" of length " + std::to_string(array.size()) + " doesn't fit into " +
 								 description->get_parameter_type());
 	}
 	for (unsigned int i = 0; i < array.size(); i++) {

--- a/project/src/rpcruntime_encoder.cpp
+++ b/project/src/rpcruntime_encoder.cpp
@@ -1,6 +1,7 @@
 #include "rpcruntime_encoder.h"
 #include "rpcruntime_encoded_function_call.h"
 #include "rpcruntime_protocol_description.h"
+#include <string>
 
 RPCRuntimeEncoder::RPCRuntimeEncoder(const RPCRunTimeProtocolDescription &description)
 	: description(&description) {}
@@ -11,7 +12,7 @@ RPCRuntimeEncodedFunctionCall RPCRuntimeEncoder::encode(int id) const {
             return RPCRuntimeEncodedFunctionCall{function};
 		}
 	}
-	throw std::runtime_error("unknown function name");
+    throw std::runtime_error("RPC: unknown function id "+std::to_string(id));
 }
 
 RPCRuntimeEncodedFunctionCall RPCRuntimeEncoder::encode(const std::string &function_name) const {
@@ -20,7 +21,7 @@ RPCRuntimeEncodedFunctionCall RPCRuntimeEncoder::encode(const std::string &funct
             return RPCRuntimeEncodedFunctionCall{function};
 		}
 	}
-	throw std::runtime_error("unknown function name: " + function_name);
+    throw std::runtime_error("RPC: unknown function name: " + function_name);
 }
 
 bool RPCRuntimeEncoder::function_exists_for_encoding(const std::string &function_name) const {

--- a/project/src/rpcruntime_paramter_description.cpp
+++ b/project/src/rpcruntime_paramter_description.cpp
@@ -186,8 +186,8 @@ int RPCRuntimeEnumerationParameter::Enum_value::to_int() const
 {
 	int retval;
 	std::stringstream ss(value);
-	if (!(ss >> retval)){
-		throw std::domain_error("empty string cannot be converted to int");
+    if (!(ss >> std::noskipws >> retval)){
+        throw std::domain_error("RPC: empty enum string cannot be converted to int");
 	}
 	return retval;
 }
@@ -196,5 +196,5 @@ bool RPCRuntimeEnumerationParameter::Enum_value::is_int() const
 {
 	int retval = 0;
 	std::stringstream ss(value);
-	return static_cast<bool>(ss >> retval);
+    return static_cast<bool>(ss >> std::noskipws >> retval);
 }

--- a/project/src/rpcruntime_protocol_description.cpp
+++ b/project/src/rpcruntime_protocol_description.cpp
@@ -50,7 +50,7 @@ static RPCRuntimeParameterDescription parse_integer_parameter(QXmlStreamReader &
 	} else if (signed_string == "False" || signed_string == "false") {
 		integer_parameter.is_signed = false;
 	} else {
-		throw std::runtime_error("Integer parameter has no propper signed attribute");
+        throw std::runtime_error("RPC: Integer parameter has no propper signed attribute");
 	}
 	xml_reader.skipCurrentElement(); //integer
 
@@ -165,7 +165,7 @@ static RPCRuntimeParameterDescription parse_parameter(QXmlStreamReader &xml_read
 	}
 	//unknown type
 	qDebug() << "unknown parameter type" << type_name;
-	throw std::runtime_error("unknown parameter type: " + type_name.toString().toStdString());
+    throw std::runtime_error("RPC: unknown parameter type: " + type_name.toString().toStdString());
 }
 
 static std::vector<RPCRuntimeParameterDescription> parse_parameters(QXmlStreamReader &xml_reader) {
@@ -329,7 +329,7 @@ const RPCRuntimeFunction &RPCRunTimeProtocolDescription::get_function(int id) co
 		}
 	}
 	//don't have a function with the appropriate ID
-	throw std::runtime_error(std::to_string(id) + " is not a valid reply- or request ID");
+    throw std::runtime_error("RPC: " +std::to_string(id) + " is not a valid reply- or request ID");
 }
 
 const RPCRuntimeFunction &RPCRunTimeProtocolDescription::get_function(const std::string &name) const {
@@ -339,7 +339,7 @@ const RPCRuntimeFunction &RPCRunTimeProtocolDescription::get_function(const std:
 		}
 	}
 	//don't have a function with the appropriate name
-	throw std::runtime_error("\"" + name + "\" is not a valid function name");
+    throw std::runtime_error("RPC: \"" + name + "\" is not a valid function name");
 }
 
 bool RPCRunTimeProtocolDescription::has_function(const std::string &name) const {

--- a/project/src/rpcruntime_transfer.cpp
+++ b/project/src/rpcruntime_transfer.cpp
@@ -32,10 +32,10 @@ RPCRuntimeDecodedFunctionCall RPCRuntimeTransfer::decode() const {
 	std::stringstream ss;
 	ss.str({reinterpret_cast<const char *>(data.data()), data.size()});
 	unsigned char id;
-	ss >> id;
+    ss >> std::noskipws >> id;
 	ss.exceptions(std::stringstream::badbit | std::stringstream::failbit | std::stringstream::eofbit);
 	if (!ss) {
-		throw std::runtime_error("No available data to decode");
+        throw std::runtime_error("RPC: No available data to decode");
 	}
 
 	auto &function = protocol->get_function(id);


### PR DESCRIPTION
-error messages now with an leading "RPC: "